### PR TITLE
Add inline annotations to small functions

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -28,46 +28,57 @@ impl Default for Board {
 }
 
 impl Board {
+    #[inline(always)]
     pub fn pieces(&self, piece: Piece) -> BitBoard {
         self.inner.pieces(piece)
     }
 
+    #[inline(always)]
     pub fn colors(&self, color: Color) -> BitBoard {
         self.inner.colors(color)
     }
 
+    #[inline(always)]
     pub fn occupied(&self) -> BitBoard {
         self.inner.colors(Color::White) | self.inner.colors(Color::Black)
     }
 
+    #[inline(always)]
     pub fn side_to_move(&self) -> Color {
         self.inner.side_to_move()
     }
 
+    #[inline(always)]
     pub fn castle_rights(&self, color: Color) -> &CastleRights {
         self.inner.castle_rights(color)
     }
 
+    #[inline(always)]
     pub fn en_passant(&self) -> Option<File> {
         self.inner.en_passant()
     }
 
+    #[inline(always)]
     pub fn hash(&self) -> u64 {
         self.inner.hash()
     }
     
+    #[inline(always)]
     pub fn pinned(&self) -> BitBoard {
         self.pinned
     }
 
+    #[inline(always)]
     pub fn checkers(&self) -> BitBoard {
         self.checkers
     }
 
+    #[inline(always)]
     pub fn piece_on(&self, square: Square) -> Option<Piece> {
         Piece::ALL.iter().copied().find(|&p| self.pieces(p).has(square))
     }
 
+    #[inline(always)]
     pub fn color_on(&self, square: Square) -> Option<Color> {
         if self.colors(Color::White).has(square) {
             Some(Color::White)
@@ -78,6 +89,7 @@ impl Board {
         }
     }
 
+    #[inline(always)]
     pub fn king(&self, color: Color) -> Square {
         (self.pieces(Piece::King) & self.colors(color)).next_square().unwrap()
     }

--- a/src/board/zobrist.rs
+++ b/src/board/zobrist.rs
@@ -83,6 +83,7 @@ pub struct ZobristBoard {
 }
 
 impl ZobristBoard {
+    #[inline(always)]
     pub fn empty() -> Self {
         Self {
             pieces: [BitBoard::EMPTY; Piece::NUM],
@@ -97,26 +98,32 @@ impl ZobristBoard {
         }
     }
 
+    #[inline(always)]
     pub fn pieces(&self, piece: Piece) -> BitBoard {
         self.pieces[piece as usize]
     }
 
+    #[inline(always)]
     pub fn colors(&self, color: Color) -> BitBoard {
         self.colors[color as usize]
     }
 
+    #[inline(always)]
     pub fn side_to_move(&self) -> Color {
         self.side_to_move
     }
 
+    #[inline(always)]
     pub fn castle_rights(&self, color: Color) -> &CastleRights {
         &self.castle_rights[color as usize]
     }
 
+    #[inline(always)]
     pub fn en_passant(&self) -> Option<File> {
         self.en_passant
     }
 
+    #[inline(always)]
     pub fn hash(&self) -> u64 {
         self.hash
     }
@@ -155,6 +162,7 @@ impl ZobristBoard {
         }
     }
 
+    #[inline(always)]
     pub fn toggle_side_to_move(&mut self) {
         self.side_to_move = !self.side_to_move;
         self.hash ^= ZOBRIST.black_to_move;

--- a/src/types/src/bitboard.rs
+++ b/src/types/src/bitboard.rs
@@ -9,6 +9,7 @@ macro_rules! impl_math_ops {
             impl std::ops::$trait for BitBoard {
                 type Output = Self;
     
+                #[inline(always)]
                 fn $fn(self, other: Self) -> Self::Output {
                     Self(std::ops::$trait::$fn(self.0, other.0))
                 }
@@ -30,6 +31,7 @@ macro_rules! impl_math_assign_ops {
     ($($trait:ident,$fn:ident;)*) => {
         $(
             impl std::ops::$trait for BitBoard {
+                #[inline(always)]
                 fn $fn(&mut self, other: Self) {
                     std::ops::$trait::$fn(&mut self.0, other.0)
                 }
@@ -53,6 +55,7 @@ macro_rules! impl_shift_ops_for {
             impl std::ops::$trait<$type> for BitBoard {
                 type Output = Self;
     
+                #[inline(always)]
                 fn $fn(self, other: $type) -> Self::Output {
                     Self(std::ops::$trait::$fn(self.0, other))
                 }
@@ -64,6 +67,7 @@ macro_rules! impl_shift_assign_ops_for {
     ($type:ident; $($trait:ident,$fn:ident;)*) => {
         $(
             impl std::ops::$trait<$type> for BitBoard {
+                #[inline(always)]
                 fn $fn(&mut self, other: $type) {
                     std::ops::$trait::$fn(&mut self.0, other)
                 }
@@ -91,9 +95,12 @@ impl_shift_assign_ops!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
 macro_rules! impl_wrapping_ops {
     ($($fn:ident),*) => {
         impl BitBoard {
-            $(pub const fn $fn(self, other: Self) -> Self {
-                Self(self.0.$fn(other.0))
-            })*
+            $(
+                #[inline(always)]
+                pub const fn $fn(self, other: Self) -> Self {
+                    Self(self.0.$fn(other.0))
+                }
+            )*
         }
     };
 }
@@ -102,6 +109,7 @@ impl_wrapping_ops!(wrapping_add, wrapping_mul, wrapping_sub, wrapping_div);
 impl std::ops::Not for BitBoard {
     type Output = Self;
 
+    #[inline(always)]
     fn not(self) -> Self::Output {
         Self(!self.0)
     }
@@ -117,19 +125,23 @@ impl BitBoard {
         File::H.bitboard().0
     );
 
+    #[inline(always)]
     pub const fn popcnt(self) -> u32 {
         self.0.count_ones()
     }
 
+    #[inline(always)]
     pub const fn has(self, square: Square) -> bool {
         self.0 & square.bitboard().0 != BitBoard::EMPTY.0
     }
 
+    #[inline(always)]
     pub const fn empty(self) -> bool {
         self.0 == BitBoard::EMPTY.0
     }
 
     ///Grabs the least significant square, if it exists.
+    #[inline(always)]
     pub const fn next_square(self) -> Option<Square> {
         Square::try_index(self.0.trailing_zeros() as usize)
     }
@@ -138,6 +150,7 @@ impl BitBoard {
 impl Iterator for BitBoard {
     type Item = Square;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let square = self.next_square();
         if let Some(square) = square {
@@ -146,12 +159,14 @@ impl Iterator for BitBoard {
         square
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len(), Some(self.len()))
     }
 }
 
 impl ExactSizeIterator for BitBoard {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.popcnt() as usize
     }

--- a/src/types/src/color.rs
+++ b/src/types/src/color.rs
@@ -16,6 +16,7 @@ crate::helpers::enum_char_conv! {
 impl std::ops::Not for Color {
     type Output = Self;
 
+    #[inline(always)]
     fn not(self) -> Self::Output {
         match self {
             Self::White => Self::Black,

--- a/src/types/src/delta.rs
+++ b/src/types/src/delta.rs
@@ -4,6 +4,7 @@ use crate::*;
 pub struct SquareDelta(pub i8, pub i8);
 
 impl SquareDelta {
+    #[inline(always)]
     pub const fn add(self, square: Square) -> Option<Square> {
         macro_rules! const_try {
             ($expr:expr) => {

--- a/src/types/src/file.rs
+++ b/src/types/src/file.rs
@@ -28,6 +28,7 @@ crate::helpers::enum_char_conv! {
 }
 
 impl File {
+    #[inline(always)]
     pub const fn bitboard(self) -> BitBoard {
         BitBoard(u64::from_ne_bytes([
             0b00000001,

--- a/src/types/src/helpers.rs
+++ b/src/types/src/helpers.rs
@@ -14,6 +14,7 @@ macro_rules! simple_enum {
             pub const NUM: usize = [$(Self::$variant),*].len();
             pub const ALL: [Self; Self::NUM] = [$(Self::$variant),*];
     
+            #[inline(always)]
             pub const fn try_index(index: usize) -> Option<Self> {
                 $(#[allow(non_upper_case_globals, unused)]
                 const $variant: usize = $name::$variant as usize;)*
@@ -24,10 +25,12 @@ macro_rules! simple_enum {
                 }
             }
 
+            #[inline(always)]
             pub fn index(index: usize) -> Self {
                 Self::try_index(index).unwrap_or_else(|| panic!("Index {} is out of range.", index))
             }
 
+            #[inline(always)]
             pub const fn index_const(index: usize) -> Self {
                 if let Some(value) = Self::try_index(index) {
                     value

--- a/src/types/src/rank.rs
+++ b/src/types/src/rank.rs
@@ -28,10 +28,12 @@ crate::helpers::enum_char_conv! {
 }
 
 impl Rank {
+    #[inline(always)]
     pub const fn bitboard(self) -> BitBoard {
         BitBoard(0b11111111 << (self as usize * 8))
     }
 
+    #[inline(always)]
     pub const fn relative_to(self, color: Color) -> Self {
         if let Color::White = color {
             self

--- a/src/types/src/square.rs
+++ b/src/types/src/square.rs
@@ -49,18 +49,22 @@ impl std::fmt::Display for Square {
 }
 
 impl Square {
+    #[inline(always)]
     pub const fn new(file: File, rank: Rank) -> Self {
         Self::index_const(((rank as usize) << 3) | file as usize)
     }
 
+    #[inline(always)]
     pub const fn rank(self) -> Rank {
         Rank::index_const(self as usize >> 3)
     }
 
+    #[inline(always)]
     pub const fn file(self) -> File {
         File::index_const(self as usize & 0b000_111)
     }
 
+    #[inline(always)]
     pub const fn bitboard(self) -> BitBoard {
         BitBoard(1 << self as u8)
     }


### PR DESCRIPTION
This allows the optimizer to really do its job well. This is roughly 4x faster for Kiwipete perft 3 without LTO.