### PR TITLE
Fast `is_legal`

### DIFF
--- a/cozy-chess/Cargo.toml
+++ b/cozy-chess/Cargo.toml
@@ -24,3 +24,7 @@ criterion = "0.3"
 [[bench]]
 name = "perft"
 harness = false
+
+[[bench]]
+name = "legals"
+harness = false

--- a/cozy-chess/benches/legals.rs
+++ b/cozy-chess/benches/legals.rs
@@ -1,0 +1,225 @@
+use std::time::Duration;
+
+use cozy_chess::{
+    get_bishop_rays, get_king_moves, get_knight_moves, get_pawn_attacks, get_pawn_quiets,
+    get_rook_rays, BitBoard, Board, Move, Piece,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+const POSITIONS: &[&str] = &[
+    "Q7/5Q2/8/8/3k4/6P1/6BP/7K b - - 0 67",
+    "r4rk1/p4ppp/1q2p3/2n1P3/2p5/3bRNP1/1P3PBP/R2Q2K1 b - - 0 24",
+    "r1bq1rk1/pp3ppp/2nbpn2/3p4/3P4/1PN1PN2/1BP1BPPP/R2Q1RK1 b - - 2 10",
+    "1r4k1/1P3p2/6pp/2Pp4/4P3/PQ1K1R2/6P1/4q3 w - - 0 51",
+    "8/8/R7/4n3/4k3/6P1/6K1/8 w - - 68 164",
+    "2r3k1/1b4bp/1p2p1p1/3pNp2/3P1P1q/PB1Q3P/1P4P1/4R1K1 w - - 2 36",
+    "4rrk1/1b4bp/p1p1p1p1/3pN3/1P3q2/PQN3P1/2P1RP1P/3R2K1 b - - 0 24",
+    "rnbq1rk1/ppp1bppp/4p3/3pP1n1/2PP3P/5PP1/PP4B1/RNBQK1NR b KQ - 0 8",
+    "3r1r1k/p1p3pp/2p5/8/4K3/2N3Pb/PPP5/R1B4R b - - 0 20",
+    "r4k1r/ppq2ppp/4bB2/8/2p5/4P3/P3BPPP/1R1Q1RK1 b - - 0 17",
+    "r4rk1/1b1nq1pp/p7/3pNp2/1p3Q2/3B3P/PPP1N1R1/R2K4 w - - 2 21",
+    "8/5p2/8/p6k/8/3N4/5PPK/8 w - - 0 49",
+    "2r1rbk1/4pp1p/1Q1P1np1/2B1Nq2/P4P2/1B3P2/1PP3bP/1K1RR3 b - - 0 29",
+    "6k1/p4ppp/Bpp5/4P3/P7/4QKPb/2P3N1/3r3q w - - 5 36",
+    "3br1k1/pp1r1ppp/3pbn2/P2Np3/1PPpP3/3P1NP1/5PBP/3RR1K1 w - - 1 21",
+    "8/1p6/p3n3/4k3/8/6PR/1rr5/3R2K1 w - - 8 54",
+    "1r4k1/p4p1p/5p2/8/4P3/4K3/PPP3P1/4R3 w - - 0 34",
+    "6k1/6p1/7p/7R/7P/5n2/P3K1b1/8 b - - 2 48",
+    "2rr2k1/pp5p/3p4/4p3/2b1p3/P4QP1/1P4P1/3R2K1 w - - 0 28",
+    "q1r4k/1bR5/rp4pB/3p4/3P2nQ/8/PP3PPP/R5K1 w - - 1 29",
+    "rnbqkbnr/pppppp1p/6p1/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+    "rnbqk1nr/1p3ppp/p3p3/2bp4/4P3/5N2/PPPN1PPP/R1BQKB1R w KQkq - 0 6",
+    "r2q1rk1/1p1b1p1p/p5p1/3QP3/8/5N2/PP3PPP/2KR3R b - - 0 20",
+    "r3r2k/pbp1q2p/1p6/4n3/2NQ4/2P2pB1/P1P2P1P/2R2RK1 b - - 6 26",
+    "8/1p2k3/4rp2/p2R3Q/2q2B2/6P1/5P1P/6K1 b - - 14 73",
+];
+
+pub fn criterion_benchmark(criterion: &mut Criterion) {
+    let positions: Vec<Board> = POSITIONS.iter().map(|pos| pos.parse().unwrap()).collect();
+    let promos: &Vec<Option<Piece>> = &Piece::ALL.into_iter().map(Some).chain([None]).collect();
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::Pawn) & board.colors(board.side_to_move())).flat_map(move |from| {
+                (get_pawn_quiets(from, board.side_to_move(), BitBoard::EMPTY)
+                    | get_pawn_attacks(from, board.side_to_move()))
+                .flat_map(move |to| {
+                    promos.iter().map(move |&promotion| {
+                        (
+                            board,
+                            Move {
+                                from,
+                                to,
+                                promotion,
+                            },
+                        )
+                    })
+                })
+            })
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("pawns", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::Rook) & board.colors(board.side_to_move())).flat_map(move |from| {
+                get_rook_rays(from).map(move |to| {
+                    (
+                        board,
+                        Move {
+                            from,
+                            to,
+                            promotion: None,
+                        },
+                    )
+                })
+            })
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("rooks", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::Knight) & board.colors(board.side_to_move())).flat_map(
+                move |from| {
+                    get_knight_moves(from).map(move |to| {
+                        (
+                            board,
+                            Move {
+                                from,
+                                to,
+                                promotion: None,
+                            },
+                        )
+                    })
+                },
+            )
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("knights", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::Bishop) & board.colors(board.side_to_move())).flat_map(
+                move |from| {
+                    get_bishop_rays(from).map(move |to| {
+                        (
+                            board,
+                            Move {
+                                from,
+                                to,
+                                promotion: None,
+                            },
+                        )
+                    })
+                },
+            )
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("bishops", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::Queen) & board.colors(board.side_to_move())).flat_map(
+                move |from| {
+                    (get_rook_rays(from) | get_bishop_rays(from)).map(move |to| {
+                        (
+                            board,
+                            Move {
+                                from,
+                                to,
+                                promotion: None,
+                            },
+                        )
+                    })
+                },
+            )
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("queens", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+
+    let to_check: Vec<_> = positions
+        .iter()
+        .flat_map(move |board| {
+            (board.pieces(Piece::King) & board.colors(board.side_to_move())).flat_map(move |from| {
+                get_king_moves(from).map(move |to| {
+                    (
+                        board,
+                        Move {
+                            from,
+                            to,
+                            promotion: None,
+                        },
+                    )
+                })
+            })
+        })
+        .collect();
+    criterion
+        .benchmark_group("legality")
+        .throughput(Throughput::Elements(to_check.len() as u64))
+        .bench_function("kings", |b| {
+            b.iter(|| {
+                for &(ref board, mv) in &to_check {
+                    black_box(board.is_legal(mv));
+                }
+            })
+        });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(300).measurement_time(Duration::from_secs(30));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/cozy-chess/src/board/mod.rs
+++ b/cozy-chess/src/board/mod.rs
@@ -451,20 +451,6 @@ impl Board {
         self.try_is_legal(mv).expect("Invalid board!")
     }
 
-    /// Non-panicking version of [`Board::is_legal`].
-    /// # Errors
-    /// See [`Board::is_legal`]'s panics.
-    pub fn try_is_legal(&self, mv: Move) -> Result<bool, BoardError> {
-        let mut is_legal = false;
-        self.try_generate_moves_for(mv.from.bitboard(), |moves| {
-            if moves.has(mv) {
-                is_legal = true;
-            }
-            is_legal
-        })?;
-        Ok(is_legal)
-    }
-
     /// Play a move while checking its legality. Note that this only supports Chess960 style castling.
     /// # Panics
     /// This is guaranteed to panic if the move is illegal.

--- a/cozy-chess/src/board/movegen/mod.rs
+++ b/cozy-chess/src/board/movegen/mod.rs
@@ -236,6 +236,25 @@ impl Board {
         }
     }
 
+    fn can_castle(&self, rook: File, king_dest: File, rook_dest: File) -> bool {
+        let color = self.side_to_move();
+        let our_king = self.king(color);
+        let back_rank = Rank::First.relative_to(color);
+        let blockers = self.occupied() ^ our_king.bitboard();
+        let pinned = self.pinned();
+        let rook = Square::new(rook, back_rank);
+        let blockers = blockers ^ rook.bitboard();
+        let king_dest = Square::new(king_dest, back_rank);
+        let rook_dest = Square::new(rook_dest, back_rank);
+        let king_to_rook = get_between_rays(our_king, rook);
+        let king_to_dest = get_between_rays(our_king, king_dest);
+        let mut must_be_safe = king_to_dest | king_dest.bitboard();
+        let must_be_empty = must_be_safe | king_to_rook | rook_dest.bitboard();
+        !pinned.has(rook)
+            && (blockers & must_be_empty).is_empty()
+            && must_be_safe.all(|square| self.king_safe_on(square))
+    }
+
     fn add_king_legals<
         F: FnMut(PieceMoves) -> bool, const IN_CHECK: bool
     >(&self, mask: BitBoard, listener: &mut F) -> bool {
@@ -254,31 +273,17 @@ impl Board {
             }
         }
         if !IN_CHECK {
-            let blockers = self.occupied() ^ our_king.bitboard();
-            let pinned = self.pinned();
             let rights = self.castle_rights(color);
             let back_rank = Rank::First.relative_to(color);
-            let mut handle_castling = |rook, king_dest, rook_dest| {
-                let rook = Square::new(rook, back_rank);
-                let blockers = blockers ^ rook.bitboard();
-                let king_dest = Square::new(king_dest, back_rank);
-                let rook_dest = Square::new(rook_dest, back_rank);
-                let king_to_rook = get_between_rays(our_king, rook);
-                let king_to_dest = get_between_rays(our_king, king_dest);
-                let mut must_be_safe = king_to_dest | king_dest.bitboard();
-                let must_be_empty = must_be_safe | king_to_rook | rook_dest.bitboard();
-                let can_castle = !pinned.has(rook)
-                    && (blockers & must_be_empty).is_empty()
-                    && must_be_safe.all(|square| self.king_safe_on(square));
-                if can_castle {
-                    moves |= rook.bitboard();
-                }
-            };
             if let Some(rook) = rights.short {
-                handle_castling(rook, File::G, File::F);
+                if self.can_castle(rook, File::G, File::F) {
+                    moves |= Square::new(rook, back_rank).bitboard();
+                }
             }
             if let Some(rook) = rights.long {
-                handle_castling(rook, File::C, File::D);
+                if self.can_castle(rook, File::C, File::D) {
+                    moves |= Square::new(rook, back_rank).bitboard();
+                }
             }
         }
         if !moves.is_empty() {
@@ -382,6 +387,82 @@ impl Board {
             0 => self.add_all_legals::<_, false>(mask, &mut listener),
             1 => self.add_all_legals::<_, true>(mask ,&mut listener),
             _ => self.add_king_legals::<_, true>(mask, &mut listener)
+        })
+    }
+
+    fn king_is_legal(&self, mv: Move) -> bool {
+        let castles = self.castle_rights(self.side_to_move());
+        let back_rank = Rank::First.relative_to(self.side_to_move());
+        if let Some(rook) = castles.short {
+            let rook_square = Square::new(rook, back_rank);
+            if rook_square == mv.to && self.can_castle(rook, File::G, File::F) {
+                return true;
+            }
+        }
+        if let Some(rook) = castles.long {
+            let rook_square = Square::new(rook, back_rank);
+            if rook_square == mv.to && self.can_castle(rook, File::C, File::D) {
+                return true;
+            }
+        }
+        if !get_king_moves(mv.from).has(mv.to) {
+            return false;
+        }
+        if mv.promotion.is_some() {
+            return false;
+        }
+        self.king_safe_on(mv.to)
+    }
+
+    /// Non-panicking version of [`Board::is_legal`].
+    /// # Errors
+    /// See [`Board::is_legal`]'s panics.
+    pub fn try_is_legal(&self, mv: Move) -> Result<bool, BoardError> {
+        if !self.colors(self.side_to_move()).has(mv.from) {
+            return Ok(false);
+        }
+
+        let king_sq = self.try_king(self.side_to_move())?;
+        if mv.from == king_sq {
+            return Ok(self.king_is_legal(mv));
+        }
+
+        let target_squares = match self.checkers().popcnt() {
+            0 => self.target_squares::<false>(),
+            1 => {
+                if self.pinned().has(mv.from) && !get_line_rays(king_sq, mv.from).has(mv.to) {
+                    return Ok(false)
+                }
+                self.target_squares::<true>()
+            }
+            _ => return Ok(false),
+        };
+
+        Ok(match self.piece_on(mv.from) {
+            None | Some(Piece::King) => false, // impossible
+            Some(Piece::Pawn) => {
+                let mut is_legal = false;
+                self.try_generate_moves_for(mv.from.bitboard(), |moves| {
+                    if moves.has(mv) {
+                        is_legal = true;
+                    }
+                    is_legal
+                })?;
+                is_legal
+            }
+            Some(Piece::Rook) => {
+                (target_squares & get_rook_rays(mv.from)).has(mv.to)
+                    && (get_between_rays(mv.from, mv.to) & self.occupied()).is_empty()
+            }
+            Some(Piece::Bishop) => {
+                (target_squares & get_bishop_rays(mv.from)).has(mv.to)
+                    && (get_between_rays(mv.from, mv.to) & self.occupied()).is_empty()
+            }
+            Some(Piece::Knight) => (target_squares & get_knight_moves(mv.from)).has(mv.to),
+            Some(Piece::Queen) => {
+                (target_squares & (get_rook_rays(mv.from) | get_bishop_rays(mv.from))).has(mv.to)
+                    && (get_between_rays(mv.from, mv.to) & self.occupied()).is_empty()
+            }
         })
     }
 }

--- a/cozy-chess/src/board/movegen/tests.rs
+++ b/cozy-chess/src/board/movegen/tests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::*;
 
 fn perft(board: &Board, depth: u8) -> u64 {
@@ -175,4 +177,108 @@ fn subset_movegen_kiwipete() {
     let board = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
         .parse().unwrap();
     visit(&board, 4);
+}
+
+fn test_is_legal(board: Board) {
+    let mut legals = HashSet::new();
+    board.generate_moves(|mvs| {
+        legals.extend(mvs);
+        false
+    });
+
+    const PROMOS: [Option<Piece>; 7] = [
+        None,
+        Some(Piece::Pawn),
+        Some(Piece::Knight),
+        Some(Piece::Bishop),
+        Some(Piece::Rook),
+        Some(Piece::Queen),
+        Some(Piece::King),
+    ];
+
+    for from in Square::ALL {
+        for to in Square::ALL {
+            for promotion in PROMOS {
+                let mv = Move {
+                    from,
+                    to,
+                    promotion,
+                };
+                assert_eq!(legals.contains(&mv), board.is_legal(mv), "{}", mv);
+            }
+        }
+    }
+}
+
+#[test]
+fn legality_simple() {
+    test_is_legal(Board::default());
+    test_is_legal(
+        "rk2r3/pn1p1p1p/1p4NB/2pP1K2/4p2N/1P3BP1/P1P3PP/1R3q2 w - - 2 32"
+            .parse()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn legality_castles() {
+    test_is_legal(
+        "rnbqk2r/ppppbp1p/5np1/4p3/4P3/3P1N2/PPP1BPPP/RNBQK2R w KQkq - 0 5"
+            .parse()
+            .unwrap(),
+    );
+    test_is_legal(
+        "rnbqk2r/ppppbp1p/5npB/4p3/4P3/3P1N2/PPP1BPPP/RN1QK2R b KQkq - 1 5"
+            .parse()
+            .unwrap(),
+    );
+    test_is_legal(
+        "r1bqk2r/ppppbp1p/2n2npB/4p3/4P3/2NP1N2/PPPQBPPP/R3K2R w KQq - 6 8"
+            .parse()
+            .unwrap(),
+    );
+    test_is_legal(
+        "r1bqk2r/ppppbp1p/2n2npB/4p3/4P3/2NP1N2/PPPQBPPP/R2K3R b q - 7 8"
+            .parse()
+            .unwrap(),
+    )
+}
+
+#[test]
+fn legality_castles_960() {
+    test_is_legal(
+        Board::from_fen(
+            "rq1kr3/p1ppbp1p/bpn3pB/3Np3/3P4/1P1Q1Nn1/P1P1BPPP/R2KR3 w AEae - 3 15",
+            true,
+        )
+        .unwrap(),
+    );
+    test_is_legal(
+        Board::from_fen(
+            "rq1kr3/p1ppbp1p/bpn3pB/3Np3/3P4/1P1Q1Nn1/P1P1BPPP/R2KR3 b AEae - 3 15",
+            true,
+        )
+        .unwrap(),
+    );
+    test_is_legal(
+        Board::from_fen(
+            "rk2r3/pqppbp1p/bpn3pB/3Npn2/3P4/1P1Q1N2/P1P2PPP/RKRB4 w ACa - 3 15",
+            true,
+        )
+        .unwrap(),
+    );
+}
+
+#[test]
+fn legality_en_passant() {
+    test_is_legal(
+        "rk2r3/pn1p1p1p/1p4NB/q1pP1K2/4p2b/1P3NP1/P1P3PP/R1RB4 w - - 0 29"
+            .parse()
+            .unwrap(),
+    );
+    test_is_legal(
+        "rk2r3/pn1p1p1p/1p4NB/2pP1K2/4p2N/qP4P1/P1P3PP/R1RB4 w - c6 0 30"
+            .parse()
+            .unwrap(),
+    );
 }


### PR DESCRIPTION
This PR makes `Board::is_legal` much faster (2.5x-3.5x). It also adds reasonably rigorous tests that `is_legal` agrees with movegen.