### PR TITLE
Remove zero-width space characters in CastleRights docs.

### DIFF
--- a/types/src/castling.rs
+++ b/types/src/castling.rs
@@ -12,13 +12,13 @@ pub struct CastleRights {
 impl CastleRights {
     /// Empty [`CastleRights`].
     /// # Examples
-    /// ``​`
+    /// ```
     /// # use cozy_chess_types::*;
     /// assert_eq!(CastleRights::EMPTY, CastleRights {
     ///    short: None,
     ///    long: None
     /// });
-    /// ``​`
+    /// ```
     pub const EMPTY: CastleRights = CastleRights {
         short: None,
         long: None


### PR DESCRIPTION
No idea how those got there, but they mess up the docs.rs rendering!

I searched and this seems to be the only occurrence of these characters in this repository.
